### PR TITLE
Add 'order' and 'supplierinvoice' to FORTNOX_SCOPES

### DIFF
--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -53,6 +53,8 @@ export const FORTNOX_SCOPES = [
   "companyinformation",
   "customer",
   "invoice",
+  "order",
   "supplier",
+  "supplierinvoice",
   "bookkeeping"
 ];


### PR DESCRIPTION
Adds two Fortnox API scopes to FORTNOX_SCOPES:

supplierinvoice: required to read supplier invoice data (payables / outflows). The supplier scope alone grants vendor-record access but NOT the invoices themselves — supplier-side cash-flow data is gated behind a separate scope.
order: required to read order data for downstream forecasting.

Symptom encountered: fortnox_cash_flow_forecast returns receivables (via existing invoice + customer scopes) but supplier invoices show as 0 with a "missing scope" warning. Empirical root-cause: OAuth grant requests only the 5 scopes currently listed, so the supplier-invoice endpoint returns 401/403.

Two-line addition · no API surface change · existing users with active tokens will need to re-authorize to pick up the new scopes (standard for any scope expansion).