### PR TITLE
Fix data-integrity and reliability bugs in analytics tools

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,16 @@ export const MAX_FETCH_ALL_PAGES = 100;
 export const FETCH_ALL_PAGE_SIZE = 100;
 export const FETCH_ALL_DELAY_MS = 250; // Stay under 25 req/5sec rate limit
 
+// Minimum spacing between request *starts* so concurrent callers become a steady
+// stream instead of an instant burst (25 req / 5 s = 200ms; small buffer added).
+export const MIN_REQUEST_SPACING_MS = 210;
+
+// Transient-failure retry (HTTP 429 and 5xx). Backoff honors Retry-After when present,
+// otherwise exponential: RETRY_BASE_DELAY_MS * 2^attempt, capped at RETRY_MAX_DELAY_MS.
+export const MAX_RETRY_ATTEMPTS = 5;
+export const RETRY_BASE_DELAY_MS = 1000;
+export const RETRY_MAX_DELAY_MS = 8000;
+
 // Response format enum
 export enum ResponseFormat {
   MARKDOWN = "markdown",

--- a/src/schemas/vouchers.ts
+++ b/src/schemas/vouchers.ts
@@ -188,16 +188,17 @@ export const AccountActivitySchema = z.object({
   max_vouchers: z.number()
     .int()
     .min(10)
-    .max(500)
+    .max(2000)
     .default(500)
-    .describe("Maximum vouchers to scan (10-500). Use date filtering for larger datasets."),
+    .describe("Maximum vouchers to scan (10-2000, default 500). Each voucher requires a separate detail fetch, so large values are slow — prefer narrowing the date range (e.g. one month at a time) for big financial years. If the cap is reached the scan is truncated and summary totals are INCOMPLETE."),
   response_format: z.nativeEnum(ResponseFormat)
     .default(ResponseFormat.MARKDOWN)
     .describe("Output format: 'markdown' or 'json'")
-}).strict().refine(
-  (data) => data.account_number !== undefined || data.account_numbers !== undefined || data.account_range !== undefined,
-  { message: "Must specify at least one of: account_number, account_numbers, or account_range" }
-);
+}).strict();
+// NOTE: The "at least one of account_number/account_numbers/account_range" rule is
+// enforced in the tool handler, NOT via .refine() here. A .refine() wraps the schema
+// in a ZodEffects, which has no `.shape` — so the MCP SDK publishes an EMPTY input
+// schema, clients then send all args as strings, and parsing rejects every call.
 
 export type AccountActivityInput = z.infer<typeof AccountActivitySchema>;
 
@@ -237,9 +238,9 @@ export const SearchVouchersSchema = z.object({
   max_vouchers: z.number()
     .int()
     .min(10)
-    .max(500)
+    .max(2000)
     .default(500)
-    .describe("Maximum vouchers to scan (10-500). Use date filtering for larger datasets."),
+    .describe("Maximum vouchers to scan (10-2000, default 500). Each voucher requires a separate detail fetch, so large values are slow — prefer narrowing the date range (e.g. one month at a time) for big financial years. If the cap is reached the scan is truncated and summary totals are INCOMPLETE."),
   response_format: z.nativeEnum(ResponseFormat)
     .default(ResponseFormat.MARKDOWN)
     .describe("Output format: 'markdown' or 'json'")

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,40 +5,100 @@ import {
   FORTNOX_API_BASE_URL,
   RATE_LIMIT_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
+  MIN_REQUEST_SPACING_MS,
+  MAX_RETRY_ATTEMPTS,
+  RETRY_BASE_DELAY_MS,
+  RETRY_MAX_DELAY_MS,
   MAX_FETCH_ALL_RESULTS,
   MAX_FETCH_ALL_PAGES,
   FETCH_ALL_PAGE_SIZE,
   FETCH_ALL_DELAY_MS
 } from "../constants.js";
 
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 // Rate limiting state
 let requestTimestamps: number[] = [];
+// Serialization gate so concurrent callers queue through the limiter one at a time,
+// turning a parallel burst into an evenly paced stream.
+let rateLimitGate: Promise<void> = Promise.resolve();
 
 /**
  * Simple rate limiter for Fortnox API (25 requests per 5 seconds)
  */
 async function waitForRateLimit(): Promise<void> {
-  const now = Date.now();
+  // Serialize concurrent callers: each waits for the previous one to finish pacing
+  // before computing its own delay. Without this, N parallel requests all read the same
+  // window state and fire at once (the burst that triggers Fortnox 429s).
+  const prior = rateLimitGate;
+  let release!: () => void;
+  rateLimitGate = new Promise<void>((resolve) => { release = resolve; });
+  await prior;
 
-  // Remove timestamps outside the window
-  requestTimestamps = requestTimestamps.filter(
-    (ts) => now - ts < RATE_LIMIT_WINDOW_MS
-  );
+  try {
+    let now = Date.now();
 
-  // If at limit, wait for oldest request to expire
-  if (requestTimestamps.length >= RATE_LIMIT_REQUESTS) {
-    const oldestTimestamp = requestTimestamps[0];
-    const waitTime = RATE_LIMIT_WINDOW_MS - (now - oldestTimestamp) + 50; // +50ms buffer
-    if (waitTime > 0) {
-      await new Promise((resolve) => setTimeout(resolve, waitTime));
-    }
-    // Clean up again after waiting
+    // Remove timestamps outside the sliding window
     requestTimestamps = requestTimestamps.filter(
-      (ts) => Date.now() - ts < RATE_LIMIT_WINDOW_MS
+      (ts) => now - ts < RATE_LIMIT_WINDOW_MS
     );
-  }
 
-  requestTimestamps.push(Date.now());
+    // Sliding-window cap: if at limit, wait for the oldest request to expire
+    if (requestTimestamps.length >= RATE_LIMIT_REQUESTS) {
+      const oldestTimestamp = requestTimestamps[0];
+      const waitTime = RATE_LIMIT_WINDOW_MS - (now - oldestTimestamp) + 50; // +50ms buffer
+      if (waitTime > 0) {
+        await sleep(waitTime);
+      }
+      now = Date.now();
+      requestTimestamps = requestTimestamps.filter(
+        (ts) => now - ts < RATE_LIMIT_WINDOW_MS
+      );
+    }
+
+    // Minimum spacing between request starts: smooths the allowed burst into a steady
+    // stream so we don't trip Fortnox's per-second enforcement.
+    const lastTimestamp = requestTimestamps[requestTimestamps.length - 1];
+    if (lastTimestamp !== undefined) {
+      const sinceLast = Date.now() - lastTimestamp;
+      if (sinceLast < MIN_REQUEST_SPACING_MS) {
+        await sleep(MIN_REQUEST_SPACING_MS - sinceLast);
+      }
+    }
+
+    requestTimestamps.push(Date.now());
+  } finally {
+    // Let the next queued caller proceed.
+    release();
+  }
+}
+
+/** Status codes worth retrying: rate limiting and transient server errors. */
+function isRetryableStatus(status: number | undefined): boolean {
+  return status === 429 || status === 500 || status === 502 || status === 503;
+}
+
+/**
+ * How long to wait before the next retry. Honors a Retry-After header (seconds or HTTP
+ * date) when Fortnox sends one; otherwise exponential backoff with jitter, capped.
+ */
+function computeRetryDelayMs(error: unknown, attempt: number): number {
+  const header = axios.isAxiosError(error)
+    ? error.response?.headers?.["retry-after"]
+    : undefined;
+  if (header !== undefined) {
+    const asSeconds = Number(header);
+    if (!Number.isNaN(asSeconds)) {
+      return Math.min(asSeconds * 1000, RETRY_MAX_DELAY_MS);
+    }
+    const asDate = Date.parse(String(header));
+    if (!Number.isNaN(asDate)) {
+      return Math.min(Math.max(asDate - Date.now(), 0), RETRY_MAX_DELAY_MS);
+    }
+  }
+  const backoff = Math.min(RETRY_BASE_DELAY_MS * 2 ** attempt, RETRY_MAX_DELAY_MS);
+  const jitter = backoff * 0.25 * (((attempt * 2654435761) % 1000) / 1000); // deterministic jitter
+  return backoff + jitter;
 }
 
 /**
@@ -51,8 +111,6 @@ export async function fortnoxRequest<T>(
   data?: unknown,
   params?: Record<string, string | number | boolean | undefined>
 ): Promise<T> {
-  await waitForRateLimit();
-
   // Get access token using the token provider
   // In local mode, userId is undefined and ignored
   // In remote mode, userId comes from the request context
@@ -83,11 +141,23 @@ export async function fortnoxRequest<T>(
     data
   };
 
-  try {
-    const response = await axios(config);
-    return response.data;
-  } catch (error) {
-    throw handleApiError(error, endpoint);
+  // Retry loop: transient failures (429 / 5xx) back off and retry instead of being
+  // surfaced as a hard error that silently drops the caller's data.
+  let attempt = 0;
+  for (;;) {
+    await waitForRateLimit();
+    try {
+      const response = await axios(config);
+      return response.data;
+    } catch (error) {
+      const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+      if (isRetryableStatus(status) && attempt < MAX_RETRY_ATTEMPTS) {
+        await sleep(computeRetryDelayMs(error, attempt));
+        attempt++;
+        continue;
+      }
+      throw handleApiError(error, endpoint);
+    }
   }
 }
 

--- a/src/tools/biAnalytics.ts
+++ b/src/tools/biAnalytics.ts
@@ -279,7 +279,12 @@ export function registerBIAnalyticsTools(server: McpServer): void {
         };
 
         const receivables = receivablesResult.items.filter(inv => filterByDueDate(inv.DueDate));
-        const payables = payablesResult.items.filter(inv => filterByDueDate(inv.DueDate));
+        // Fortnox returns supplier-invoice Balance as a string (unlike customer
+        // invoices, which return a number). Coerce here so all downstream sums add
+        // numerically instead of concatenating strings.
+        const payables = payablesResult.items
+          .filter(inv => filterByDueDate(inv.DueDate))
+          .map(inv => ({ ...inv, Balance: Number(inv.Balance) || 0 }));
 
         // Generate time buckets
         const buckets = generateTimeBucketKeys(today, futureDate, params.group_by);

--- a/src/tools/supplierInvoices.ts
+++ b/src/tools/supplierInvoices.ts
@@ -526,7 +526,13 @@ Examples:
           (r) => r.MetaInformation?.["@TotalResources"] || 0
         );
 
-        let invoices = result.items;
+        // Fortnox returns supplier-invoice Balance and Total as strings. Coerce to
+        // numbers up front so all sums add numerically instead of concatenating.
+        let invoices = result.items.map(inv => ({
+          ...inv,
+          Balance: Number(inv.Balance) || 0,
+          Total: Number(inv.Total) || 0
+        }));
 
         // Apply min_amount filter
         if (params.min_amount !== undefined) {

--- a/src/tools/vouchers.ts
+++ b/src/tools/vouchers.ts
@@ -488,6 +488,22 @@ Examples:
     },
     async (params: AccountActivityInput) => {
       try {
+        // Enforce the account-filter requirement here (kept out of the Zod schema as a
+        // .refine() so the published MCP input schema stays a plain object — see schema note).
+        if (
+          params.account_number === undefined &&
+          params.account_numbers === undefined &&
+          params.account_range === undefined
+        ) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: "Error: Must specify at least one of: account_number, account_numbers, or account_range."
+            }],
+            isError: true
+          };
+        }
+
         // Build account filter set
         const accountFilter = new Set<number>();
         if (params.account_number !== undefined) {
@@ -564,6 +580,12 @@ Examples:
 
         const accountSummary = new Map<number, { debit: number; credit: number; count: number }>();
 
+        // Track voucher-detail fetches that failed (e.g. Fortnox rate limiting). These
+        // are skipped, which silently drops their rows — so we count them and treat any
+        // failure as an incomplete result below, rather than reporting partial totals as
+        // if they were complete.
+        let failedDetailFetches = 0;
+
         // Process vouchers in batches of 10
         const batchSize = 10;
         for (let i = 0; i < voucherList.length; i += batchSize) {
@@ -579,6 +601,7 @@ Examples:
               const detail = await fortnoxRequest<VoucherResponse>(detailEndpoint, "GET", undefined, detailParams);
               return detail.Voucher;
             } catch {
+              failedDetailFetches++;
               return null;
             }
           });
@@ -639,6 +662,31 @@ Examples:
               .sort((a, b) => a.account - b.account)
           : undefined;
 
+        // Loud incompleteness signal. Totals can be PARTIAL for two distinct reasons:
+        //  (1) the voucher LIST was truncated at the scan cap, or
+        //  (2) individual voucher DETAIL fetches failed (e.g. rate limiting) and were skipped.
+        // Either one makes the summary unreliable, so surface both — and a big year can have
+        // thousands of vouchers while the matching accounts sit in the unscanned tail,
+        // producing a misleading "0 matches".
+        const incompleteReasons: string[] = [];
+        if (result.truncated) {
+          incompleteReasons.push(
+            `scanned only ${voucherList.length} of ${totalVouchers} vouchers (max_vouchers=${params.max_vouchers})` +
+            (matchingTransactions.length === 0
+              ? "; 0 matches most likely means the matching accounts are among the unscanned vouchers, NOT that there was no activity"
+              : "")
+          );
+        }
+        if (failedDetailFetches > 0) {
+          incompleteReasons.push(
+            `${failedDetailFetches} voucher detail fetch(es) failed and were skipped (often Fortnox rate limiting — avoid running account scans in parallel, then retry)`
+          );
+        }
+        const summaryComplete = !result.truncated && failedDetailFetches === 0;
+        const truncationWarning = incompleteReasons.length > 0
+          ? `INCOMPLETE RESULTS: ${incompleteReasons.join("; ")}. Summary totals are PARTIAL. For complete figures, narrow the date range (e.g. one month at a time)${result.truncated ? " or raise max_vouchers" : ""} and retry.`
+          : undefined;
+
         const output: Record<string, unknown> = {
           filter: {
             accounts: Array.from(accountFilter),
@@ -651,6 +699,9 @@ Examples:
           total_vouchers_available: totalVouchers,
           truncated: result.truncated,
           truncation_reason: result.truncationReason,
+          failed_detail_fetches: failedDetailFetches,
+          summary_complete: summaryComplete,
+          warning: truncationWarning,
           matching_transactions: matchingTransactions.length,
           summary: summaryArray,
           transactions: matchingTransactions
@@ -678,9 +729,9 @@ Examples:
           lines.push(`**Financial Year**: ${params.financial_year}`);
           lines.push(`**Vouchers Scanned**: ${voucherList.length} | **Matching Transactions**: ${matchingTransactions.length}`);
 
-          if (result.truncated) {
+          if (truncationWarning) {
             lines.push("");
-            lines.push(`⚠️ **Note**: ${result.truncationReason}`);
+            lines.push(`> ⚠️ **${truncationWarning}**`);
           }
 
           if (summaryArray && summaryArray.length > 0) {
@@ -718,7 +769,9 @@ Examples:
             }
           } else {
             lines.push("");
-            lines.push("*No transactions found matching the account criteria.*");
+            lines.push((result.truncated || failedDetailFetches > 0)
+              ? "*No matches among the successfully scanned vouchers — but the scan was incomplete (truncated and/or some detail fetches failed), so matching transactions may exist. Narrow the date range and retry before concluding there was no activity.*"
+              : "*No transactions found matching the account criteria.*");
           }
 
           textContent = lines.join("\n");


### PR DESCRIPTION
## Summary

Four related fixes surfaced while running financial analyses (cash-flow forecasts, payables reports, and a full-year ledger P&L) against a live Fortnox account. Each one was silently producing wrong or missing numbers.

## The fixes

### 1. Supplier-invoice amounts concatenated instead of summed
Fortnox returns supplier-invoice `Balance`/`Total` as **strings**, not numbers (customer invoices return numbers). Summing them with `sum + value` concatenated strings — e.g. the cash-flow forecast reported a net position of `-8.9e+47` from a garbage string like `"0896511802694936..."`. Coerced to numbers at the source in:
- `fortnox_cash_flow_forecast` (`biAnalytics.ts`)
- `fortnox_payables_report` (`supplierInvoices.ts`)

### 2. `fortnox_account_activity` published an empty input schema
Its Zod schema ended in `.refine()`, which wraps the object in a `ZodEffects` that has no `.shape` for the MCP SDK to read. The published `inputSchema` came out **empty**, so clients sent every argument as a string and the server rejected *every* call with a type error. Removed the top-level `.refine()` (the "at least one account filter" rule is now enforced in the handler), restoring a correct 11-property schema. `create_voucher`'s nested `VoucherRowSchema.refine()` is unaffected (nested refinements serialize fine — verified).

### 3. Loud, honest completeness reporting for `account_activity`
The tool scans vouchers client-side via an N+1 detail fetch. Previously a capped or rate-limited scan **silently dropped data** while still reporting `summary_complete: true` (a one-month scan was losing ~95% of its rows unnoticed). Now:
- Raised the scan cap (500 → 2000).
- Added `failed_detail_fetches` and a `summary_complete` flag.
- Emits an explicit `warning` when the voucher list is truncated **or** any detail fetch fails, with guidance to narrow the date range.

### 4. Resilient shared HTTP layer (`api.ts`)
Root cause of the silent drops: `429`/`5xx` responses were thrown immediately (no retry, `Retry-After` ignored), and the rate limiter allowed an instant 25-request burst that tripped Fortnox's per-second enforcement. Now:
- **Retry with backoff** on `429`/`5xx`, honoring `Retry-After`, exponential otherwise (1s→8s cap, up to 5 attempts).
- **Serialized rate limiter** with ~210ms minimum spacing, turning concurrent bursts into a steady ~5 req/s stream so we stop *causing* 429s.

This hardens every tool, not just `account_activity`.

## Verification

Before/after on a single-month `account_activity` scan (accounts 3000–3999):

| | Before | After |
|---|--:|--:|
| failed_detail_fetches | 253 / 275 | **0** |
| matching transactions | 7 | **43** |
| summary_complete | `true` (wrong) | `true` (correct) |

End-to-end: built a complete 12-month ledger P&L (~3,000 sequential voucher detail fetches, 765s) with **zero dropped fetches** and every month `summary_complete: true`. The resulting revenue reconciles against billed invoices (ex-VAT ledger vs incl-VAT billing). Before these fixes the same workload silently returned ~5% of the data.

## Notes
- No dependency or build-output changes; source only.
- `npm run build` (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)