### PR TITLE
Security hardening: token lifecycle, destructive hints, JWT, CORS, redirect URI validation

### DIFF
--- a/scripts/get-token.ts
+++ b/scripts/get-token.ts
@@ -14,6 +14,7 @@
  */
 
 import http from "http";
+import crypto from "crypto";
 import { URL } from "url";
 import readline from "readline";
 
@@ -31,6 +32,7 @@ const CLIENT_ID = requireEnv("FORTNOX_CLIENT_ID");
 const CLIENT_SECRET = requireEnv("FORTNOX_CLIENT_SECRET");
 const REDIRECT_PORT = 8888;
 const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}/callback`;
+const OAUTH_STATE = crypto.randomBytes(16).toString("hex");
 
 const SCOPES = [
   "customer",
@@ -48,12 +50,21 @@ async function getAuthorizationCode(): Promise<string> {
       if (url.pathname === "/callback") {
         const code = url.searchParams.get("code");
         const error = url.searchParams.get("error");
+        const state = url.searchParams.get("state");
 
         if (error) {
-          res.writeHead(400, { "Content-Type": "text/html" });
-          res.end(`<h1>Error: ${error}</h1><p>${url.searchParams.get("error_description")}</p>`);
+          // Plain text so attacker-influenced params can't be interpreted as HTML
+          res.writeHead(400, { "Content-Type": "text/plain" });
+          res.end(`OAuth error: ${error}\n${url.searchParams.get("error_description") || ""}`);
           reject(new Error(error));
           server.close();
+          return;
+        }
+
+        if (state !== OAUTH_STATE) {
+          // Not the callback we initiated — ignore it and keep waiting
+          res.writeHead(400, { "Content-Type": "text/plain" });
+          res.end("State mismatch: this response does not belong to the flow started by this script.");
           return;
         }
 
@@ -81,7 +92,7 @@ async function getAuthorizationCode(): Promise<string> {
       authUrl.searchParams.set("scope", SCOPES.join(" "));
       authUrl.searchParams.set("response_type", "code");
       authUrl.searchParams.set("access_type", "offline");
-      authUrl.searchParams.set("state", "fortnox-mcp");
+      authUrl.searchParams.set("state", OAUTH_STATE);
 
       console.log("\n╔════════════════════════════════════════════════════════════╗");
       console.log("║           FORTNOX OAUTH2 AUTHORIZATION                      ║");
@@ -140,10 +151,9 @@ async function main() {
     console.log("║                    SUCCESS!                                 ║");
     console.log("╚════════════════════════════════════════════════════════════╝\n");
 
-    console.log("Add these to your environment:\n");
+    console.log("Add this to your environment (FORTNOX_CLIENT_ID and");
+    console.log("FORTNOX_CLIENT_SECRET are already set):\n");
     console.log("─────────────────────────────────────────────────────────────");
-    console.log(`export FORTNOX_CLIENT_ID="${CLIENT_ID}"`);
-    console.log(`export FORTNOX_CLIENT_SECRET="${CLIENT_SECRET}"`);
     console.log(`export FORTNOX_REFRESH_TOKEN="${tokens.refresh_token}"`);
     console.log("─────────────────────────────────────────────────────────────\n");
 
@@ -151,7 +161,7 @@ async function main() {
     console.log(JSON.stringify({
       "env": {
         "FORTNOX_CLIENT_ID": CLIENT_ID,
-        "FORTNOX_CLIENT_SECRET": CLIENT_SECRET,
+        "FORTNOX_CLIENT_SECRET": "<your FORTNOX_CLIENT_SECRET>",
         "FORTNOX_REFRESH_TOKEN": tokens.refresh_token
       }
     }, null, 2));

--- a/src/auth/databaseProvider.ts
+++ b/src/auth/databaseProvider.ts
@@ -4,6 +4,13 @@ import { ITokenProvider, TokenInfo, AuthRequiredError } from "./types.js";
 import { ITokenStorage } from "./storage/types.js";
 import { getFortnoxCredentials } from "./credentials.js";
 
+// Fortnox rejects an expired or revoked refresh token with 400 (invalid_grant).
+// 401 means bad client credentials and 5xx/network errors are transient —
+// neither invalidates the user's refresh token.
+function isRefreshTokenRejected(error: unknown): boolean {
+  return error instanceof AxiosError && error.response?.status === 400;
+}
+
 // Token provider for remote mode (multi-user with database storage)
 export class DatabaseTokenProvider implements ITokenProvider {
   private clientId: string;
@@ -150,8 +157,9 @@ export class DatabaseTokenProvider implements ITokenProvider {
       await this.storeTokens(userId, newTokens);
       return newTokens.accessToken;
     } catch (error) {
-      // Clear invalid tokens
-      await this.storage.delete(userId);
+      if (isRefreshTokenRejected(error)) {
+        await this.storage.delete(userId);
+      }
       throw this.handleAuthError(error, "Failed to refresh access token");
     }
   }

--- a/src/auth/envVarProvider.ts
+++ b/src/auth/envVarProvider.ts
@@ -4,6 +4,13 @@ import { ITokenProvider, TokenInfo, AuthRequiredError } from "./types.js";
 import { getFortnoxCredentials } from "./credentials.js";
 import { readPersistedTokens, persistTokens } from "./fileTokenStore.js";
 
+// Fortnox rejects an expired or revoked refresh token with 400 (invalid_grant).
+// 401 means bad client credentials and 5xx/network errors are transient —
+// neither invalidates the refresh token.
+function isRefreshTokenRejected(error: unknown): boolean {
+  return error instanceof AxiosError && error.response?.status === 400;
+}
+
 interface TokenResponse {
   access_token: string;
   refresh_token: string;
@@ -141,7 +148,9 @@ export class EnvVarTokenProvider implements ITokenProvider {
       this.storeTokens(response.data);
       return this.tokens!.accessToken;
     } catch (error) {
-      this.tokens = null;
+      if (isRefreshTokenRejected(error)) {
+        this.tokens = null;
+      }
       throw this.handleAuthError(error, "Failed to refresh access token");
     }
   }

--- a/src/auth/oauthProvider.ts
+++ b/src/auth/oauthProvider.ts
@@ -70,6 +70,13 @@ export class FortnoxProxyOAuthProvider implements OAuthServerProvider {
     serverUrl: string,
     tokenStorage: ITokenStorage
   ) {
+    if (jwtSecret.length < 32) {
+      throw new Error(
+        "JWT_SECRET must be at least 32 characters: every user's session " +
+        "and token isolation depends on it being unguessable. " +
+        "Generate one with: openssl rand -base64 32"
+      );
+    }
     this.jwtSecret = new TextEncoder().encode(jwtSecret);
     this.serverUrl = serverUrl;
     this.tokenProvider = new DatabaseTokenProvider(tokenStorage);
@@ -303,6 +310,7 @@ export class FortnoxProxyOAuthProvider implements OAuthServerProvider {
     try {
       const { payload } = await jose.jwtVerify(token, this.jwtSecret, {
         issuer: this.serverUrl,
+        algorithms: [JWT_ALGORITHM],
       });
 
       if (payload.type !== expectedType) {

--- a/src/auth/oauthProvider.ts
+++ b/src/auth/oauthProvider.ts
@@ -12,6 +12,7 @@ import {
   OAuthTokenRevocationRequest,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { InvalidClientMetadataError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import { ITokenStorage } from "./storage/types.js";
 import { DatabaseTokenProvider } from "./databaseProvider.js";
 import { FORTNOX_SCOPES } from "./credentials.js";
@@ -354,6 +355,42 @@ export class FortnoxProxyOAuthProvider implements OAuthServerProvider {
   }
 }
 
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+// Registration is open (no authentication), and the OAuth callback redirects
+// the browser to whatever redirect_uri the client registered. Block cleartext
+// HTTP off loopback so authorization codes can't travel unencrypted, and
+// block script-capable schemes outright. Custom app schemes (cursor://,
+// vscode://, ...) stay allowed for native clients per RFC 8252.
+const FORBIDDEN_REDIRECT_SCHEMES = new Set(["javascript:", "data:", "file:", "vbscript:"]);
+
+function validateRedirectUris(redirectUris: string[] | undefined): void {
+  if (!redirectUris || redirectUris.length === 0) {
+    throw new InvalidClientMetadataError("At least one redirect_uri is required");
+  }
+
+  for (const uri of redirectUris) {
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      throw new InvalidClientMetadataError(`redirect_uri is not a valid URL: ${uri}`);
+    }
+
+    if (FORBIDDEN_REDIRECT_SCHEMES.has(parsed.protocol)) {
+      throw new InvalidClientMetadataError(`redirect_uri scheme is not allowed: ${uri}`);
+    }
+
+    if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+      throw new InvalidClientMetadataError(
+        `http redirect_uri is only allowed on loopback: ${uri}`
+      );
+    }
+  }
+}
+
 // Dynamic client registration store
 class InMemoryClientsStore implements OAuthRegisteredClientsStore {
   private clients: Map<string, OAuthClientInformationFull> = new Map();
@@ -365,6 +402,8 @@ class InMemoryClientsStore implements OAuthRegisteredClientsStore {
   registerClient(
     client: Omit<OAuthClientInformationFull, "client_id" | "client_id_issued_at">
   ): OAuthClientInformationFull {
+    validateRedirectUris(client.redirect_uris);
+
     const clientId = `client_${crypto.randomUUID()}`;
     const fullClient: OAuthClientInformationFull = {
       ...client,

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,8 +115,16 @@ async function runLocalHTTP(): Promise<void> {
   });
 
   const port = parseInt(process.env.PORT || "3000", 10);
-  app.listen(port, () => {
-    console.error(`[FortnoxMCP] http://localhost:${port}/mcp`);
+  // The local HTTP transport has no authentication, so only bind beyond
+  // loopback when explicitly requested via HOST.
+  const host = process.env.HOST || "127.0.0.1";
+  app.listen(port, host, () => {
+    console.error(`[FortnoxMCP] http://${host}:${port}/mcp`);
+    if (host !== "127.0.0.1" && host !== "localhost") {
+      console.error(
+        `[FortnoxMCP] WARNING: /mcp has no authentication and is reachable by anyone who can connect to ${host}:${port}`
+      );
+    }
   });
 }
 

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -613,7 +613,7 @@ Returns:
       inputSchema: InvoiceActionSchema,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true
       }
@@ -716,7 +716,7 @@ Returns:
       inputSchema: InvoiceActionSchema,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true
       }
@@ -772,7 +772,7 @@ Returns:
       inputSchema: SendInvoiceEmailSchema,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true
       }

--- a/src/tools/supplierInvoices.ts
+++ b/src/tools/supplierInvoices.ts
@@ -428,7 +428,7 @@ Returns:
       inputSchema: ApproveSupplierInvoiceSchema,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true
       }

--- a/src/tools/vouchers.ts
+++ b/src/tools/vouchers.ts
@@ -298,7 +298,7 @@ Example:
       inputSchema: CreateVoucherSchema,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true
       }

--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,7 @@
   ],
   "headers": [
     {
-      "source": "/(.*)",
+      "source": "/(mcp|token|register)",
       "headers": [
         {
           "key": "Access-Control-Allow-Origin",
@@ -25,6 +25,23 @@
         {
           "key": "Access-Control-Allow-Headers",
           "value": "Content-Type, Authorization, mcp-session-id"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET, OPTIONS"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "Content-Type"
         }
       ]
     }


### PR DESCRIPTION
While reviewing the server before self-hosting it in production, we did a security audit of the codebase (auth/token handling, network surface, tool layer, and supply chain). The good news: we found no malicious code, and the overall design — tenant isolation via signed JWTs, hardcoded Fortnox base URLs, encoded path params — is sound. This PR fixes the concrete issues the audit surfaced. Each commit is self-contained and reviewable on its own:

## Commits

1. **Only clear stored tokens when Fortnox rejects the refresh token** — the refresh flow deleted stored tokens on *any* error, so a transient Fortnox 5xx or network blip permanently destroyed the user's refresh token and forced a full re-auth. Tokens are now deleted only on a definitive 400 (`invalid_grant`); a 401 (misconfigured client credentials) no longer wipes user tokens either.

2. **Mark irreversible operations as destructive** — `fortnox_approve_supplier_invoice` releases an invoice for payment, `fortnox_bookkeep_invoice`/`fortnox_create_voucher` post irreversible ledger entries, `fortnox_credit_invoice` creates a financial document, and `fortnox_send_invoice_email` cannot be recalled — yet all five were annotated `destructiveHint: false`, so MCP clients that gate confirmation prompts on the hint execute them silently.

3. **Enforce JWT_SECRET strength and pin the JWT algorithm** — every tenant's isolation rests on `JWT_SECRET`, but it was only checked for presence. Now requires ≥ 32 characters (checked in the provider constructor, covering both the Vercel handler and `runRemoteServer`) and pins `jwtVerify` to HS256.

4. **Bind the unauthenticated local HTTP transport to loopback** — in `TRANSPORT=http` local mode, `/mcp` has no authentication and listened on all interfaces. Defaults to `127.0.0.1` now; a `HOST` env var opts into wider exposure with a logged warning.

5. **Validate redirect URIs on dynamic client registration** — `/register` is unauthenticated and accepted any `redirect_uris`, which the OAuth callback then redirects to. Rejects malformed URIs, script-capable schemes (`javascript:`, `data:`, `file:`, `vbscript:`), and cleartext `http` off loopback, via the SDK's `invalid_client_metadata` error. Custom app schemes (`cursor://`, `vscode://`) remain allowed per RFC 8252.

6. **Scope wildcard CORS to endpoints that need it** — CORS headers applied to every route; now limited to `/mcp`, `/token`, `/register`, and `/.well-known/*`. The browser-navigation endpoints (`/authorize`, the Fortnox callback) gain nothing from CORS and no longer opt out of same-origin protections.

7. **Harden `scripts/get-token.ts`** — random per-run OAuth `state` that is actually verified on the callback (it was a never-checked constant), plain-text error responses instead of interpolating query params into HTML (same fix the server callback got in 501ee13), and the client secret is no longer echoed to the terminal.

## Behavior changes to note

- Deployments with a `JWT_SECRET` shorter than 32 characters will fail fast at startup with a clear error message (commit 3). Intentional, since a brute-forceable secret allows forging any user's session, but worth calling out for existing deployments.
- Local HTTP mode is no longer reachable from other machines unless `HOST` is set explicitly (commit 4).

`npm run build` passes on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
